### PR TITLE
Fix: Right hand reset_motors.py integer underflow issue

### DIFF
--- a/calibrate_motors.py
+++ b/calibrate_motors.py
@@ -6,22 +6,43 @@ import numpy as np
 
 from ruka_hand.control.hand import *
 from ruka_hand.utils.file_ops import get_repo_root
+from ruka_hand.utils.trajectory import move_to_pos
 
 
 class HandCalibrator:
     def __init__(
         self,
-        data_save_path,
         hand_type,
-        curr_lim=50,
-        testing=False,
+        curr_lim=100,
+        no_load_curr = 5,
         motor_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        verbose=True,
     ):
         self.hand = Hand(hand_type)
         self.curr_lim = curr_lim
-        self.testing = testing
+        self.no_load_curr = no_load_curr
         self.motor_ids = motor_ids
-        self.data_save_path = data_save_path
+        self.verbose = verbose
+
+        self.curled = None
+        self.tensioned = None
+
+        # self.reset_motors()
+
+    def reset_motors(self):
+        print("Resetting motors...")
+        for _ in range(10):
+            curr_pos = self.hand.read_pos()
+            time.sleep(.1)
+            print(f"curr_pos: {curr_pos}, des_pos: {self.hand.tensioned_pos}")
+            move_to_pos(curr_pos=curr_pos, des_pos=self.hand.tensioned_pos, hand=self.hand, traj_len=50)
+
+        print("Motors reset! Now, manually adjust each tendon.")
+        self.hand.dxl_client.set_torque_enabled(False)
+        input("Press enter when done...")
+        self.hand.dxl_client.set_torque_enabled(True)
+
+        print(f"Tension pos: {[self.hand.read_pos()[i - 1] for i in self.motor_ids]}")
 
     def find_bound(self, motor_id):
         # Add cases for specific motors here
@@ -29,74 +50,137 @@ class HandCalibrator:
         # check to see if other fingers need raising
         # should we run three times? maybe more? to make sure it actually does it right
         # use present position
-        t = 2
-        if motor_id in [4, 5]:
+        t_curl = 1.5
+        if motor_id in [1, 2, 3]:
+            self.curr_lim = 40
+        elif motor_id in [4, 5]:
             if motor_id == 4:
                 self.curr_lim = 250
             else:
                 self.curr_lim = 200
-            t = 5
-        if self.testing:
+            t_curl = 3
+
+        # People can manually rotate the servos to give tension, so that the start pos can vary
+        # Reset the motors to be around 400
+        start_pos = np.array([self.hand.read_pos()[i - 1] for i in self.motor_ids])
+        tension_pos = start_pos[motor_id - 1]
+        if self.verbose:
             print("------------ MOTOR ", motor_id, " ------------")
+            print(f" - Manually tensioned at {tension_pos}")
+
         if self.hand.hand_type == "right":
-            start_pos = 100
-            f = 1
+            l_bound = max(100, tension_pos)
+            u_bound = 3800
         elif self.hand.hand_type == "left":
-            start_pos = 4000
-            f = -1
-        l_bound = 100
-        u_bound = 4000
-        pos = np.array([start_pos] * 11)
+            l_bound = 300
+            u_bound = min(tension_pos, 4000)
+
+        pos = start_pos.copy()
         cur = 1000000
-        while abs(u_bound - l_bound) > 10 or f * cur > self.curr_lim:
-            com_pos = (u_bound + l_bound) // 2 - 1
-            # if self.testing: print(u_bound, "    ", l_bound, "         ", com_pos)
-            pos[motor_id - 1] = com_pos
+        init_curl = True
+        target_pos = (u_bound + l_bound) // 2 - 1
+
+        while abs(u_bound - l_bound) > 10:  # or abs(cur) < self.curr_lim:
+            # last_target = target_pos
+            target_pos = (u_bound + l_bound) // 2 - 1
+
+            # if not init_curl and abs(cur) >= self.curr_lim: 
+            #     if self.hand.hand_type == "right":
+            #         target_pos = max(last_target, target_pos)
+            #     else:
+            #         target_pos = min(last_target, target_pos)
+            
+            pos[motor_id - 1] = target_pos
             self.hand.set_pos(pos)
-            time.sleep(t)
+            time.sleep(t_curl)
+
             cur = self.hand.read_single_cur(motor_id)
             pres_pos = self.hand.read_pos()[motor_id - 1]
-            if self.testing:
-                print(
-                    u_bound,
-                    "    ",
-                    l_bound,
-                    "         ",
-                    com_pos,
-                    "         ",
-                    pres_pos,
-                )
-            if self.testing:
-                print(cur)
-            if f * cur < self.curr_lim:
+            if self.verbose:
+                print(f"L: {l_bound}\tU: {u_bound}\tT: {target_pos}\tP: {pres_pos}\tCurrent: {cur}")
+
+            # Reached the max curl
+            if self.hand.hand_type == "right" and (u_bound - pres_pos < 2):
+                break
+            elif self.hand.hand_type == "left" and (pres_pos - l_bound < 2):
+                break
+
+            # Skip the calibration when there is no load
+            if init_curl and abs(cur) < self.no_load_curr:
+                print("No load. Skipping calibration.")
+                break
+            init_curl = False
+
+            if abs(cur) < self.curr_lim:
                 if self.hand.hand_type == "right":
+                    print(" - increasing the lower bound")
                     l_bound = pres_pos + 1
                     u_bound -= 1
                 else:
+                    print(" - decreasing the upper bound")
                     u_bound = pres_pos - 1
                     l_bound += 1
             else:
                 if self.hand.hand_type == "right":
-                    u_bound = pres_pos + 1
+                    print(" - decreasing the upper bound")
+                    u_bound = int((3*pres_pos + u_bound)/4)
                 else:
-                    l_bound = pres_pos - 1
-        return pres_pos
+                    print(" - increasing the lower bound")
+                    l_bound = int((3*pres_pos + l_bound)/4)
+
+        pres_pos = self.hand.read_pos()[motor_id - 1]
+        print(f"Tension pos: {tension_pos}, curled pos: {pres_pos}")
+        self.hand.set_pos(start_pos)
+        time.sleep(2)
+
+        return tension_pos, pres_pos
 
     def find_curled_tensioned(self):
-        if self.hand.hand_type == "right":
-            f = 1
-        else:
-            f = -1
-        curled = np.array([0] * len(self.motor_ids))
-        for i in range(len(curled)):
-            curled[i] = self.find_bound(self.motor_ids[i])
-        tensioned = [x - f * 1100 for x in curled]
-        return curled, tensioned
+        self.curled = np.array([0] * len(self.motor_ids))
+        self.tensioned = np.array([0] * len(self.motor_ids))
+        for i in range(len(self.motor_ids)):
+            self.tensioned[i], self.curled[i] = self.find_bound(self.motor_ids[i])
 
-    def save_motor_limits(self):
-        curled, _ = self.find_curled_tensioned()
-        np.save(self.data_save_path, curled)
+    def test_curled(self):
+        start_pos = self.tensioned - 100
+        start_pos[start_pos < 100] = 100
 
+        for motor_id in self.motor_ids:
+            # Reset pos
+            curr_pos = self.hand.read_pos()
+            time.sleep(.1)
+            move_to_pos(curr_pos=curr_pos, des_pos=start_pos, hand=self.hand, traj_len=50, sleep_time=0.02)
+
+            print(f"Testing motor {motor_id}")
+            time.sleep(.1)
+            curr_pos = self.hand.read_pos()
+            test_pos = start_pos.copy()
+            test_pos[motor_id-1] = self.curled[motor_id-1]
+            move_to_pos(curr_pos=curr_pos, des_pos=test_pos, hand=self.hand, traj_len=200, sleep_time=0.01)
+
+        # Reset pos
+        curr_pos = self.hand.read_pos()
+        time.sleep(.1)
+        move_to_pos(curr_pos=curr_pos, des_pos=start_pos, hand=self.hand, traj_len=50, sleep_time=0.02)
+
+        print("Testing all motors")
+        time.sleep(.1)
+        curr_pos = self.hand.read_pos()
+        test_pos = self.curled.copy()
+        # test_pos[0] = curr_pos[0]  # pass thumb abduction
+        test_pos[1:2] = curr_pos[1:2]  # pass thumb joint abductions
+        move_to_pos(curr_pos=curr_pos, des_pos=test_pos, hand=self.hand, traj_len=200, sleep_time=0.01)
+
+
+    def save_motor_limits(self, save_path):
+        if self.curled is None or self.tensioned is None:
+            self.find_curled_tensioned()
+        np.savez(save_path, curled=self.curled, tensioned=self.tensioned)
+
+    def load_motor_limits(self, load_path):
+        data = np.load(load_path)
+        self.curled = data["curled"]
+        self.tensioned = data["tensioned"]
 
 def parse_args():
     import argparse
@@ -110,26 +194,38 @@ def parse_args():
         help="Type of hand to calibrate (right or left)",
     )
     parser.add_argument(
-        "--testing",
+        "--verbose",
         type=bool,
         default=True,
         help="Enable testing mode with debug prints",
     )
     parser.add_argument(
-        "--curr-lim", type=int, default=50, help="Current limit for calibration"
+        "--curr-lim", type=int, default=100, help="Current limit for calibration"
     )
     return parser.parse_args()
-
 
 if __name__ == "__main__":
     args = parse_args()
     repo_root = get_repo_root()
     if not os.path.exists(f"{repo_root}/motor_limits"):
         os.makedirs(f"{repo_root}/motor_limits")
+
+    limit_file = f"{repo_root}/motor_limits/{args.hand_type}_motor_limits.npz"
+
     calibrator = HandCalibrator(
-        data_save_path=f"{repo_root}/motor_limits/{args.hand_type}_motor_limits.npy",
         hand_type=args.hand_type,
         curr_lim=args.curr_lim,
-        testing=args.testing,
+        verbose=args.verbose,
     )
-    calibrator.save_motor_limits()
+    calibrator.reset_motors()
+    calibrator.find_curled_tensioned()
+    calibrator.save_motor_limits(limit_file)
+
+    calibrator2 = HandCalibrator( 
+        hand_type=args.hand_type,
+        curr_lim=args.curr_lim,
+        verbose=args.verbose,
+    )
+    calibrator2.load_motor_limits(limit_file)
+    while True:
+        calibrator2.test_curled()

--- a/ruka_hand/control/hand.py
+++ b/ruka_hand/control/hand.py
@@ -63,7 +63,9 @@ class Hand:
                 )
             else:
                 self.curled_bound = np.ones(11) * MOTOR_RANGES_RIGHT
-            self.tensioned_pos = self.curled_bound - MOTOR_RANGES_RIGHT
+            
+            # NOTE: In the instruction, "Set position to around 100 for the right hand"
+            self.tensioned_pos = 100 + self.curled_bound - MOTOR_RANGES_RIGHT
 
             self.min_lim, self.max_lim = self.tensioned_pos, self.curled_bound
         elif hand_type == "left":

--- a/ruka_hand/control/hand.py
+++ b/ruka_hand/control/hand.py
@@ -65,7 +65,8 @@ class Hand:
                 self.curled_bound = np.ones(11) * MOTOR_RANGES_RIGHT
             
             # NOTE: In the instruction, "Set position to around 100 for the right hand"
-            self.tensioned_pos = 100 + self.curled_bound - MOTOR_RANGES_RIGHT
+            # Too close 0 can mess up the pos reading
+            self.tensioned_pos = 300 + self.curled_bound - MOTOR_RANGES_RIGHT
 
             self.min_lim, self.max_lim = self.tensioned_pos, self.curled_bound
         elif hand_type == "left":
@@ -74,7 +75,8 @@ class Hand:
                     f"{repo_root}/motor_limits/left_motor_limits.npy"
                 )
             else:
-                self.curled_bound = 4000 - np.ones(11) * MOTOR_RANGES_LEFT
+                # Too close 0/4096 can mess up the pos reading
+                self.curled_bound = 3800 - np.ones(11) * MOTOR_RANGES_LEFT
             self.tensioned_pos = self.curled_bound + MOTOR_RANGES_LEFT
 
             self.min_lim, self.max_lim = self.curled_bound, self.tensioned_pos


### PR DESCRIPTION
Thank you for making the RUKA hand!

When using `reset_motors.py` with the right hand, the hand's `self.tensioned_pos` was set to 0. It caused integer underflow, resulting in erratic motor positions with large values like 4294967295.

```
curr_pos: [101, 100, 100, 101, 101, 98, 99, 98, 101, 101, 101], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 1, 0, 3, 3, 0, 1, 2, 1, 2, 2], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 2, 1, 0, 1, 4294967295, 1, 2, 2], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 1, 1, 0, 1, 4294967273, 1, 4294967295, 4294967295], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 1, 1, 0, 1, 4294967250, 0, 4294967258, 4294967286], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 1, 0, 0, 1, 4294967261, 1, 44, 21], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 1, 4294967295, 0, 1, 4294967265, 1, 41, 28], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 1, 4294967170, 0, 1, 4294967263, 1, 13, 12], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 1, 4294967174, 0, 1, 4294967292, 1, 5, 6], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 1, 4294967191, 0, 1, 4294967263, 1, 3, 3], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
curr_pos: [0, 0, 0, 1, 4294967201, 0, 1, 4294967262, 1, 2, 3], des_pos: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
...
```

Adding 100 to `self.tensioned_pos` fixed it and produced the output like:

```
curr_pos: [100, 100, 100, 101, 98, 101, 101, 100, 101, 101, 101], des_pos: [100. 100. 100. 100. 100. 100. 100. 100. 100. 100. 100.]
curr_pos: [100, 100, 100, 101, 99, 101, 101, 100, 101, 101, 101], des_pos: [100. 100. 100. 100. 100. 100. 100. 100. 100. 100. 100.]
curr_pos: [100, 100, 100, 101, 99, 101, 101, 100, 101, 101, 101], des_pos: [100. 100. 100. 100. 100. 100. 100. 100. 100. 100. 100.]
curr_pos: [100, 100, 100, 101, 100, 101, 101, 100, 101, 101, 101], des_pos: [100. 100. 100. 100. 100. 100. 100. 100. 100. 100. 100.]
curr_pos: [100, 100, 100, 101, 101, 101, 101, 100, 101, 101, 101], des_pos: [100. 100. 100. 100. 100. 100. 100. 100. 100. 100. 100.]
curr_pos: [100, 100, 100, 101, 101, 101, 101, 100, 101, 101, 101], des_pos: [100. 100. 100. 100. 100. 100. 100. 100. 100. 100. 100.]
curr_pos: [100, 100, 100, 101, 101, 101, 101, 100, 101, 101, 101], des_pos: [100. 100. 100. 100. 100. 100. 100. 100. 100. 100. 100.]
curr_pos: [100, 100, 100, 101, 101, 101, 101, 100, 101, 101, 101], des_pos: [100. 100. 100. 100. 100. 100. 100. 100. 100. 100. 100.]
...
```
